### PR TITLE
Add Plane_Copy to Eternity config

### DIFF
--- a/Build/Configurations/Includes/Eternity_linedefs.cfg
+++ b/Build/Configurations/Includes/Eternity_linedefs.cfg
@@ -2523,7 +2523,45 @@ udmf
 	plane
 	{
 		title = "Plane";
-		
+		118
+		{
+			title = "Plane Copy (slope)";
+			id = "Plane_Copy";
+			requiresactivation = false;
+			
+			arg0
+			{
+				title = "Front Floor Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Front Ceiling Tag";
+				type = 13;
+			}
+			arg2
+			{
+				title = "Back Floor Tag";
+				type = 13;
+			}
+			arg3
+			{
+				title = "Back Ceiling Tag";
+				type = 13;
+			}
+			arg4
+			{
+				title = "Share Slope";
+				type = 12;
+				enum
+				{
+					1 = "Front floor to back sector";
+					2 = "Back floor to front sector";
+					4 = "Front ceiling to back sector";
+					8 = "Back ceiling to front sector";
+				}
+			}
+		}
 		181
 		{
 			title = "Plane Align (slope)";


### PR DESCRIPTION
No code changes were needed to get rendering working. Eternity has Plane_Copy as of around 15:15 2017/01/05: https://github.com/team-eternity/eternity/commit/792b39a04830e837512d8a95e640a294924a161b