### PR TITLE
Eternity config: add thing class1 class2 class3

### DIFF
--- a/Build/Configurations/Includes/Eternity_linedefs.cfg
+++ b/Build/Configurations/Includes/Eternity_linedefs.cfg
@@ -3079,7 +3079,6 @@ udmf
 				title = "Opacity";
 			}
 		}
-		140 = NULL;	// not yet
 		185
 		{
 			title = "Sector Rotate Flat";

--- a/Build/Configurations/Includes/Eternity_linedefs.cfg
+++ b/Build/Configurations/Includes/Eternity_linedefs.cfg
@@ -1353,6 +1353,40 @@ udmf
 				enum = "reset_tics";
 			}
 		}
+		273
+		{
+			title = "Stairs build up (Doom mode, crushing)";
+			id = "Stairs_BuildUpDoomCrush";
+			arg0
+			{
+				title = "Start Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "stair_speeds";
+				default = 2;
+			}
+			arg2
+			{
+				title = "Step Height";
+				default = 8;
+			}
+			arg3
+			{
+				title = "Build Step Delay";
+				type = 11;
+				enum = "delay_tics";
+			}
+			arg4
+			{
+				title = "Reset Delay";
+				type = 11;
+				enum = "reset_tics";
+			}
+		}
 	}
 
 

--- a/Build/Configurations/Includes/Eternity_linedefs.cfg
+++ b/Build/Configurations/Includes/Eternity_linedefs.cfg
@@ -467,22 +467,73 @@ udmf
 		}
 	}
 
-	line
-	{
-		title = "Line";
-		
-		9
-		{
-			title = "Line Horizon";
-			id = "Line_Horizon";
-			requiresactivation = false;
-		}	
-		
-	}
-
 	door
 	{
-		
+		105
+		{
+			title = "Door Raise after Delay";
+			id = "Door_WaitRaise";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "flat_speeds";
+				default = 16;
+			}
+			arg2
+			{
+				title = "Open delay";
+				type = 11;
+				enum = "generic_door_delays";
+				default = 35;
+			}
+			arg3
+			{
+				title = "Close delay";
+				type = 11;
+				enum = "generic_door_delays";
+				default = 150;
+			}
+			arg4
+			{
+				title = "Light Tag";
+				type = 13;
+			}
+		}
+		106
+		{
+			title = "Door Close after Delay";
+			id = "Door_WaitClose";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "flat_speeds";
+				default = 16;
+			}
+			arg2
+			{
+				title = "Delay";
+				type = 11;
+				enum = "generic_door_delays";
+				default = 150;
+			}
+			arg3
+			{
+				title = "Light Tag";
+				type = 13;
+			}
+		}
 		249
 		{
 			title = "Door Close Wait Open";
@@ -502,10 +553,10 @@ udmf
 			}
 			arg2
 			{
-				title = "Delay";
+				title = "Delay (octics)";
 				type = 11;
 				enum = "generic_door_delays";
-				default = 34;
+				default = 240;
 			}
 			arg3
 			{
@@ -517,11 +568,159 @@ udmf
 
 	floor
 	{
+		20
+		{
+//			id = "Floor_LowerByValue";
+			arg1
+			{
+				default = 8;
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		21
+		{
+//			id = "Floor_LowerToLowest";
+			arg1	// speed
+			{
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		22
+		{
+//			id = "Floor_LowerToNearest";
+			arg1
+			{
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		23
+		{
+//			id = "Floor_RaiseByValue";
+			arg1
+			{
+				default = 8;
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg4
+			{
+				title = "Crushing damage";
+			}
+		}
+		24
+		{
+//			id = "Floor_RaiseToHighest";
+			arg1	// speed
+			{
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg3
+			{
+				title = "Crushing damage";
+			}
+		}
+		25
+		{
+//			id = "Floor_RaiseToNearest";
+			arg1
+			{
+				default = 32;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg3
+			{
+				title = "Crushing damage";
+			}
+		}
+		28
+		{
+			title = "Floor Raise and Crush";
+//			id = "Floor_RaiseAndCrush";			
+			arg1
+			{
+				default = 8;
+			}
+			arg2
+			{
+				default = 10;
+			}
+		}
+		35
+		{
+//			id = "Floor_RaiseByValueTimes8";
+			arg1
+			{
+				default = 32;
+			}
+			arg2
+			{
+				title = "Raise by (* 8)";
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg4
+			{
+				title = "Crushing damage";
+			}
+		}
+		36
+		{
+//			id = "Floor_LowerByValueTimes8";
+			arg1
+			{
+				default = 32;
+			}
+			arg2
+			{
+				title = "Lower by (* 8)";
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
 		37
 		{
 			title = "Floor Move to Value";
 			id = "Floor_MoveToValue";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -532,12 +731,38 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
 				title = "Target Height";
 			}
+			arg3
+			{
+				title = "Negate height";
+				type = 11;
+				enum = "noyes";
+			}
+			arg4
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		66
+		{
+//			id = "Floor_LowerInstant";
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		67
+		{
+//			id = "Floor_RaiseInstant";
 			arg3
 			{
 				title = "Change";
@@ -546,15 +771,39 @@ udmf
 			}
 			arg4
 			{
-				title = "Crush Damage";
+				title = "Crushing damage";
 			}
 		}
-		
+		68
+		{
+//			id = "Floor_MoveToValueTimes8";
+			arg1
+			{
+				default = 32;
+			}
+			arg2
+			{
+				title = "Target Height * 8";
+			}
+			arg3
+			{
+				title = "Negate Height";
+				type = 11;
+				enum = "noyes";
+			}
+			arg4
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		95 = NULL;	// FloorAndCeiling_*ByValue really are elevators
+		96 = NULL;
 		138
 		{
 			title = "Floor Waggle";
 			id = "Floor_Waggle";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -580,12 +829,10 @@ udmf
 				default = 5;
 			}
 		}
-		
 		200
 		{
-			title = "Floor Generic Change";
+			title = "Generic Floor (Boom-style)";
 			id = "Generic_Floor";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -596,7 +843,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -636,12 +883,71 @@ udmf
 				}
 			}
 		}
-		
+		228
+		{
+			title = "Platform Raise Tx0";
+			id = "Plat_RaiseAndStayTx0";
+			
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 4;
+			}
+			arg2
+			{
+				title = "Lockout Mode";
+				type = 11;
+				enum
+				{
+					0 = "Lockout in Heretic only";
+					1 = "Don't lockout";
+					2 = "Lockout in all games";
+				}
+			}
+		}
+		230
+		{
+			title = "Platform Raise by Value Tx (* 8)";
+			id = "Plat_UpByValueStayTx";
+			
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 4;
+			}
+			arg2
+			{
+				title = "Raise by (* 8)";
+			}
+		}
+		231
+		{
+			title = "Platform Toggle Ceiling";
+			id = "Plat_ToggleCeiling";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+		}
 		235
 		{
-			title = "Transfer Floor Texture and Special form Back Side";
+			title = "Transfer Floor Texture and Special from Back Side";
 			id = "Floor_TransferTrigger";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -652,7 +958,6 @@ udmf
 		{
 			title = "Transfer Floor Texture and Special using Numeric Change Model";
 			id = "Floor_TransferNumeric";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -674,7 +979,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -684,19 +989,17 @@ udmf
 			}
 			arg3 
 			{
-				title = "Crushing Damage";
+				title = "Crushing damage";
 			}
 			arg4
 			{
 				title = "Gap to ceiling";
 			}
 		}
-				
 		240
 		{
 			title = "Floor Raise by Texture";
 			id = "Floor_RaiseByTexture";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -707,7 +1010,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -715,11 +1018,14 @@ udmf
 				type = 11;
 				enum = "change";
 			}
+			arg3
+			{
+				title = "Crushing damage";
+			}
 		}
-		
 		242
 		{
-			title = "Floor Lower to Highest Floor (ZDoom)";
+			title = "Floor Lower to Highest Floor with Lip";
 			id = "Floor_LowerToHighest";
 			
 			arg0
@@ -732,25 +1038,48 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 32;
 			}
 			arg2
 			{
-				title = "Adjust Target Height";
+				title = "Lip (subtract 128)";
 			}
 			arg3
 			{
-				title = "Force Adjust";
+				title = "Always have lip";
 				type = 11;
 				enum = "noyes";
 			}
 		}
-		
+		250
+		{
+			title = "Floor Lower Pillar and Raise Donut";
+			id = "Floor_Donut";
+			
+			arg0
+			{
+				title = "Pillar Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Pillar Lower Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 4;
+			}
+			arg2
+			{
+				title = "Donut Raise Speed";
+				type = 11;
+				enum = "stair_speeds";
+				default = 4;
+			}
+		}
 		256
 		{
 			title = "Floor Lower to Highest Floor";
 			id = "Floor_LowerToHighestEE";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -761,7 +1090,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -770,33 +1099,273 @@ udmf
 				enum = "change";
 			}
 		}
-		
-		250
+		257
 		{
-			title = "Floor Donut";
-			id = "Floor_Donut";
-			
+			title = "Floor Instant to Lowest Floor";
+			id = "Floor_RaiseToLowest";
 			arg0
 			{
-				title = "Center Sector Tag";
+				title = "Sector Tag";
 				type = 13;
 			}
 			arg1
 			{
-				title = "Pillar Lower Speed";
+				title = "Change";
 				type = 11;
-				enum = "plat_speeds";
-				default = 16;
+				enum = "change";
 			}
 			arg2
 			{
-				title = "Stairs Raise Speed";
-				type = 11;
-				enum = "stair_speeds";
-				default = 4;
+				title = "Crushing damage";
 			}
 		}
 		
+		258
+		{
+			title = "Floor lower to lowest ceiling";
+			id = "Floor_LowerToLowestCeiling";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Floor Lowering Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		259
+		{
+			title = "Floor raise to ceiling";
+			id = "Floor_RaiseToCeiling";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg3
+			{
+				title = "Crush damage";
+			}
+			arg4
+			{
+				title = "Gap to ceiling";
+			}
+		}
+		260
+		{
+			title = "Floor to ceiling instant";
+			id = "Floor_ToCeilingInstant";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg2
+			{
+				title = "Crush";
+			}
+			arg3
+			{
+				title = "Gap to ceiling";
+			}
+		}
+		261
+		{
+			title = "Floor lower by texture";
+			id = "Floor_LowerByTexture";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+	}
+
+	stairs
+	{
+		26 = NULL;
+		27 = NULL;
+		31 = NULL;
+		32 = NULL;
+		217
+		{
+			title = "Stairs Build up (Doom mode)";
+			id = "Stairs_BuildUpDoom";
+			arg0
+			{
+				title = "Start Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "stair_speeds";
+				default = 2;
+			}
+			arg2
+			{
+				title = "Step Height";
+				default = 8;
+			}
+			arg3
+			{
+				title = "Build Step Delay";
+				type = 11;
+				enum = "delay_tics";
+			}
+			arg4
+			{
+				title = "Reset Delay";
+				type = 11;
+				enum = "reset_tics";
+			}
+		}
+		270
+		{
+			title = "Stairs build down (Doom mode)";
+			id = "Stairs_BuildDownDoom";
+			arg0
+			{
+				title = "Start Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "stair_speeds";
+				default = 2;
+			}
+			arg2
+			{
+				title = "Step Height";
+				default = 8;
+			}
+			arg3
+			{
+				title = "Build Step Delay";
+				type = 11;
+				enum = "delay_tics";
+			}
+			arg4
+			{
+				title = "Reset Delay";
+				type = 11;
+				enum = "reset_tics";
+			}
+		}
+		271
+		{
+			title = "Stairs build up sync (Doom mode)";
+			id = "Stairs_BuildUpDoomSync";
+			arg0
+			{
+				title = "Start Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "stair_speeds";
+				default = 2;
+			}
+			arg2
+			{
+				title = "Step Height";
+				default = 8;
+			}
+			arg3
+			{
+				title = "Reset Delay";
+				type = 11;
+				enum = "reset_tics";
+			}
+		}
+		272
+		{
+			title = "Stairs build down sync (Doom mode)";
+			id = "Stairs_BuildDownDoomSync";
+			arg0
+			{
+				title = "Start Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "stair_speeds";
+				default = 2;
+			}
+			arg2
+			{
+				title = "Step Height";
+				default = 8;
+			}
+			arg3
+			{
+				title = "Reset Delay";
+				type = 11;
+				enum = "reset_tics";
+			}
+		}
+	}
+
+
+	pillar
+	{
+		94	// Pillar_BuildAndCrush
+		{
+			arg3
+			{
+				title = "Crush Damage";
+				default = 10;
+			}
+		}
 		251
 		{
 			title = "Floor and Ceiling Lower and Raise";
@@ -834,72 +1403,58 @@ udmf
 		}
 	}
 
-	stairs
-	{
-		
-		
-		217
-		{
-			title = "Stairs Build up (Doom mode)";
-			id = "Stairs_BuildUpDoom";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Movement Speed";
-				type = 11;
-				enum = "stair_speeds";
-				default = 4;
-			}
-			arg2
-			{
-				title = "Step Height";
-			}
-			arg3
-			{
-				title = "Build Step Delay";
-				type = 11;
-				enum = "delay_tics";
-				default = 35;
-			}
-			arg4
-			{
-				title = "Reset Delay";
-				type = 11;
-				enum = "reset_tics";
-			}
-		}
-	}
-
-
-	pillar
-	{
-		94	// Pillar_BuildAndCrush
-		{
-			arg3
-			{
-				title = "Crush Damage";
-				default = 100;
-			}
-			arg4
-			{
-				title = "Crush Mode";
-				type = 11;
-				enum = "crush_mode";
-			}
-		}
-	}
-
 	ceiling
 	{
 		title = "Ceiling";
-		
+		40
+		{
+//			id = "Ceiling_LowerByValue";
+			arg1
+			{
+				default = 8;
+			}
+			arg2
+			{
+				title = "Lower by";
+				default = 128;
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg4
+			{
+				title = "Crushing damage";
+			}
+		}
+		41
+		{
+//			id = "Ceiling_RaiseByValue";
+			arg1
+			{
+				default = 8;
+			}			
+			arg2
+			{
+				title = "Raise by";
+				default = 128;
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
 		42	// Ceiling Crusher Start
 		{
+			title = "Ceiling Crusher Start (Hexen-style)";
+			arg2
+			{
+				default = 10;
+			}
 			arg3
 			{
 				title = "Crush Mode";
@@ -909,46 +1464,122 @@ udmf
 		}
 		43	// Ceiling Crush Once
 		{
+			arg2
+			{
+				default = 10;
+			}
 			arg3
 			{
 				title = "Crush Mode";
 				type = 11;
 				enum = "crush_mode";
 			}
-			
 		}
-		
-		97
+		44
 		{
-			title = "Ceiling Lower And Crush Dist";
-			id = "Ceiling_LowerAndCrushDist";
-			
+//			id = "Ceiling_CrushStop";
+			arg1
+			{
+				title = "Stopping mode";
+				type = 11;
+				enum
+				{
+					0 = "Depending on game";
+					1 = "Pause crusher, keep ceiling busy";
+					2 = "Remove crusher, free ceiling for other effects";
+				}
+			}
+		}
+		45
+		{
+//			id = "Ceiling_CrushRaiseAndStay";
+			arg2
+			{
+				title = "Crush Damage";
+				default = 10;
+			}
+			arg3
+			{
+				title = "Crush Mode";
+				type = 11;
+				enum = "crush_mode";
+			}
+		}
+		47
+		{
+			title = "Ceiling Move to Value";
+			id = "Ceiling_MoveToValue";
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-		
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Target Height";
+			}
+			arg3
+			{
+				title = "Negate Height";
+				type = 11;
+				enum = "noyes";
+			}
+			arg4
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		69
+		{
+//			id = "Ceiling_MoveToValueTimes8";
+			arg1
+			{
+				default = 32;
+			}			
+			arg4
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		97
+		{
+			title = "Ceiling Lower And Crush with Gap";
+			id = "Ceiling_LowerAndCrushDist";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
 			arg1
 			{
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
 				default = 16;
-				
 			}
 		
 			arg2
 			{
 				title = "Crush Damage";
-				default = 100;
+				default = 10;
 			}
 		
 			arg3
 			{
-				title = "Lip";
+				title = "Gap to floor";
+				default = 8;
 			}
-		
 			arg4
 			{
 				title = "Crush Mode";
@@ -956,38 +1587,32 @@ udmf
 				enum = "crush_mode";
 			}
 		}
-		
 		104
 		{
-			title = "Ceiling Crush And Raise Silent Dist";
+			title = "Ceiling Crush And Raise Silent with Gap";
 			id = "Ceiling_CrushAndRaiseSilentDist";
-			
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-		
 			arg1
 			{
-				title = "Lip";
+				title = "Gap to floor";
 				default = 8;
 			}
-		
 			arg2
 			{
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 32;
+				default = 16;
 			}
-		
 			arg3
 			{
 				title = "Crush Damage";
 				default = 10;
 			}
-		
 			arg4
 			{
 				title = "Crush Mode";
@@ -999,33 +1624,28 @@ udmf
 		{
 			title = "Ceiling Crush And Raise Dist";
 			id = "Ceiling_CrushAndRaiseDist";
-			
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-		
 			arg1
 			{
-				title = "Lip";
+				title = "Gap to floor";
 				default = 8;
 			}
-		
 			arg2
 			{
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 32;
+				default = 16;
 			}
-		
 			arg3
 			{
 				title = "Crush Damage";
 				default = 10;
 			}
-		
 			arg4
 			{
 				title = "Crush Mode";
@@ -1033,46 +1653,6 @@ udmf
 				enum = "crush_mode";
 			}
 		}
-
-		45	// Ceiling Crush Once and Open
-		{
-			arg3
-			{
-				title = "Crush Mode";
-				type = 11;
-				enum = "crush_mode";
-			}
-			
-		}
-		47
-		{
-			title = "Ceiling Move to Value";
-			id = "Ceiling_MoveToValue";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Movement Speed";
-				type = 11;
-				enum = "plat_speeds";
-				default = 16;
-			}
-			arg2
-			{
-				title = "Target Height";
-			}
-			arg3
-			{
-				title = "Change";
-				type = 11;
-				enum = "change";
-			}
-		}
-		
 		192
 		{
 			title = "Ceiling Lower to Highest Floor";
@@ -1088,7 +1668,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -1109,7 +1689,6 @@ udmf
 		{
 			title = "Ceiling Lower Instantly by Value * 8";
 			id = "Ceiling_LowerInstant";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1118,6 +1697,16 @@ udmf
 			arg2
 			{
 				title = "Lower by (* 8)";
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg4
+			{
+				title = "Crushing Damage";
 			}
 		}
 		194
@@ -1134,12 +1723,17 @@ udmf
 			{
 				title = "Raise by (* 8)";
 			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
 		}
 		195
 		{
-			title = "Ceiling Crush Once and Open A";
+			title = "Ceiling Crush Once and Open (Settable Speeds)";
 			id = "Ceiling_CrushRaiseAndStayA";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1162,7 +1756,7 @@ udmf
 			arg3
 			{
 				title = "Crush Damage";
-				default = 100;
+				default = 10;
 			}
 			arg4
 			{
@@ -1170,13 +1764,11 @@ udmf
 				type = 11;
 				enum = "crush_mode";
 			}
-			
 		}
 		196
 		{
-			title = "Ceiling Crush Start A";
+			title = "Ceiling Crush Start (Settable Speeds)";
 			id = "Ceiling_CrushAndRaiseA";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1199,7 +1791,7 @@ udmf
 			arg3
 			{
 				title = "Crush Damage";
-				default = 100;
+				default = 10;
 			}
 			arg4
 			{
@@ -1207,13 +1799,11 @@ udmf
 				type = 11;
 				enum = "crush_mode";
 			}
-			
 		}
 		197
 		{
-			title = "Ceiling Crush Start A (silent)";
+			title = "Ceiling Crush Start (settable speeds, silent)";
 			id = "Ceiling_CrushAndRaiseSilentA";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1236,7 +1826,7 @@ udmf
 			arg3
 			{
 				title = "Crush Damage";
-				default = 100;
+				default = 10;
 			}
 			arg4
 			{
@@ -1244,13 +1834,11 @@ udmf
 				type = 11;
 				enum = "crush_mode";
 			}
-			
 		}
 		198
 		{
 			title = "Ceiling Raise by Value * 8";
 			id = "Ceiling_RaiseByValueTimes8";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1261,18 +1849,23 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
 				title = "Raise by (* 8)";
+			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
 			}
 		}
 		199
 		{
 			title = "Ceiling Lower by Value * 8";
 			id = "Ceiling_LowerByValueTimes8";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1283,19 +1876,27 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
 				title = "Lower by (* 8)";
 			}
+			arg3
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg4
+			{
+				title = "Crush";
+			}
 		}
-		
 		201
 		{
-			title = "Ceiling Generic Change";
+			title = "Generic Ceiling (Boom style)";
 			id = "Generic_Ceiling";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1306,7 +1907,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -1348,9 +1949,8 @@ udmf
 		}
 		205
 		{
-			title = "Ceiling Generic Crush (Doom mode)";
+			title = "Generic crusher (Boom style)";
 			id = "Generic_Crusher";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1379,14 +1979,13 @@ udmf
 			arg4
 			{
 				title = "Crush Damage";
-				default = 100;
+				default = 10;
 			}
 		}
 		252
 		{
 			title = "Ceiling Raise to Nearest Ceiling";
 			id = "Ceiling_RaiseToNearest";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1397,7 +1996,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -1438,7 +2037,6 @@ udmf
 		{
 			title = "Ceiling Lower to Floor";
 			id = "Ceiling_LowerToFloor";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1449,7 +2047,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
@@ -1468,9 +2066,8 @@ udmf
 		}
 		255
 		{
-			title = "Ceiling Crush Once and Open A (silent)";
+			title = "Ceiling Crush Once and Open (settable speeds, silent)";
 			id = "Ceiling_CrushRaiseAndStaySilA";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1493,7 +2090,7 @@ udmf
 			arg3
 			{
 				title = "Crush Damage";
-				default = 100;
+				default = 10;
 			}
 			arg4
 			{
@@ -1502,12 +2099,225 @@ udmf
 				enum = "crush_mode";
 			}
 		}
+		262
+		{
+			title = "Ceiling Raise to Highest";
+			id = "Ceiling_RaiseToHighest";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		263
+		{
+			title = "Ceiling instant to highest";
+			id = "Ceiling_ToHighestInstant";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg2
+			{
+				title = "Crushing damage";
+			}
+		}
+		264
+		{
+			title = "Ceiling lower to nearest";
+			id = "Ceiling_LowerToNearest";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg3
+			{
+				title = "Crushing damage";
+			}
+		}
+		265
+		{
+			title = "Ceiling raise to lowest";
+			id = "Ceiling_RaiseToLowest";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		266
+		{
+			title = "Ceiling raise to highest floor";
+			id = "Ceiling_RaiseToHighestFloor";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		267
+		{
+			title = "Ceiling to floor instant";
+			id = "Ceiling_ToFloorInstant";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg2
+			{
+				title = "Crushing damage";
+			}
+			arg3
+			{
+				title = "Gap to floor";
+			}
+		}
+		268
+		{
+			title = "Ceiling raise by upper texture";
+			id = "Ceiling_RaiseByTexture";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+		}
+		269
+		{
+			title = "Ceiling lower by texture";
+			id = "Ceiling_LowerByTexture";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "plat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Change";
+				type = 11;
+				enum = "change";
+			}
+			arg3
+			{
+				title = "Crushing damage";
+			}
+		}
 	}
 
 	transfer
 	{
 		title = "Transfer";
 		
+		190
+		{
+			title = "Transfer upper texture to tagged sectors' skies";
+			id = "Static_Init";
+			requiresactivation = false;
+			
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Must be 255";
+				default = 255;
+			}
+			arg2
+			{
+				title = "Flip Sky";
+				type = 11;
+				enum = "noyes";
+			}
+		}
 		209
 		{
 			title = "Transfer Heights";
@@ -1549,11 +2359,67 @@ udmf
 
 	platform
 	{
+		60
+		{
+			title = "Platform Perpetual Move (Lip 8)";
+//			id = "Plat_PerpetualRaise";
+			arg1	// speed
+			{
+				default = 8;
+			}
+		}
+		61
+		{
+//			id = "Plat_Stop";
+			arg1
+			{
+				title = "Stopping mode";
+				type = 11;
+				enum
+				{
+					0 = "Depending on current game";
+					1 = "Pause lift, keep floor busy (Doom)";
+					2 = "Remove lift, free floor for other effects (Hexen)";
+				}
+			}
+		}
+		62
+		{
+			title = "Platform Lower Wait Raise (Lip 8)";
+//			id = "Plat_DownWaitUpStay";
+			arg1	// lift
+			{
+				default = 32;
+			}
+		}
+		63
+		{
+			id = "Plat_DownByValue";
+			arg1
+			{
+				default = 32;
+			}
+		}
+		64
+		{
+//			id = "Plat_UpWaitDownStay";
+			arg1
+			{
+				default = 32;
+			}
+		}
+		65
+		{
+//			id = "Plat_UpByValue";
+			arg1
+			{
+				default = 32;
+			}
+		}
 		206
 		{
-			title = "Platform Lower Wait Raise (lip)";
+			title = "Platform Lower Wait Raise";
 			id = "Plat_DownWaitUpStayLip";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1564,14 +2430,14 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 32;
 			}
 			arg2
 			{
 				title = "Reverse Delay (tics)";
 				type = 11;
 				enum = "delay_tics";
-				default = 35;
+				default = 105;
 			}
 			arg3
 			{
@@ -1580,9 +2446,8 @@ udmf
 		}
 		207
 		{
-			title = "Platform Perpetual Move (lip)";
+			title = "Platform Perpetual Move";
 			id = "Plat_PerpetualRaiseLip";
-			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1593,80 +2458,18 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 8;
 			}
 			arg2
 			{
 				title = "Reverse Delay (tics)";
 				type = 11;
 				enum = "delay_tics";
-				default = 35;
+				default = 105;
 			}
 			arg3
 			{
 				title = "Lip Amount";
-			}
-		}
-		228
-		{
-			title = "Platform Raise Tx0";
-			id = "Plat_RaiseAndStayTx0";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Movement Speed";
-				type = 11;
-				enum = "plat_speeds";
-				default = 16;
-			}
-			arg2
-			{
-				title = "Lockout Mode";
-				type = 11;
-				enum
-				{
-					0 = "Lockout in Heretic only";
-					1 = "Don't lockout";
-					2 = "Lockout in all games";
-				}
-			}
-		}
-		230
-		{
-			title = "Platform Raise by Value Tx (* 8)";
-			id = "Plat_UpByValueStayTx";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Movement Speed";
-				type = 11;
-				enum = "plat_speeds";
-				default = 16;
-			}
-			arg2
-			{
-				title = "Raise by (* 8)";
-			}
-		}
-		231
-		{
-			title = "Platform Toggle Ceiling";
-			id = "Plat_ToggleCeiling";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
 			}
 		}
 	}
@@ -1696,20 +2499,17 @@ udmf
 				enum = "noyes";
 			}
 		}
-		74	// Teleport_NewMap
-		{
-			arg2
-			{
-				title = "Keep Orientation";
-				type = 11;
-				enum = "noyes";
-			}
-		}
+		74 = NULL;
 		215
 		{
 			title = "Teleport to Line";
 			id = "Teleport_Line";
 			
+			arg0
+			{
+				title = "Argument 1";
+				type = 0;
+			}
 			arg1
 			{
 				title = "Target Line Tag";
@@ -1750,12 +2550,6 @@ udmf
 		}
 		72 // ThrustThing
 		{
-			arg2
-			{
-				title = "No Limit";
-				type = 11;
-				enum = "noyes";
-			}
 			arg3
 			{
 				title = "Target Thing Tag";
@@ -1818,6 +2612,14 @@ udmf
 				title = "Set/Add";
 				type = 11;
 				enum = "setadd";
+			}
+		}
+		133
+		{
+//			id = "Thing_Destroy";
+			arg1
+			{
+				type = 0;
 			}
 		}
 		135	// Thing_Spawn
@@ -1973,77 +2775,42 @@ udmf
 
 	end
 	{
+		74	// Teleport_NewMap
+		{
+			title = "Exit to Map";
+			id = "Teleport_NewMap";
+			arg0
+			{
+				title = "Map Number";
+			}
+		}
 		243
 		{
 			title = "End Normal";
-			id = "Exit_Normal";
-			
-			arg0
-			{
-				title = "Position";
-			}
+			id = "Exit_Normal";			
 		}
 		244
 		{
 			title = "End Secret";
 			id = "Exit_Secret";
-			
-			arg0
-			{
-				title = "Position";
-			}
 		}
 	}
 
 	scroll
 	{
 		title = "Scroll";
-				
-		100 //Scroll_Texture_Left
-		{
-			arg1
-			{
-				title = "Sidedef Part";
-				type = 12;
-				enum = "sidedef_part";
-			}
-		}
-		
-		101 //Scroll_Texture_Right
-		{
-			arg1
-			{
-				title = "Sidedef Part";
-				type = 12;
-				enum = "sidedef_part";
-			}
-		}
-		
-		102 //Scroll_Texture_Up
-		{
-			arg1
-			{
-				title = "Sidedef Part";
-				type = 12;
-				enum = "sidedef_part";
-			}
-		}
-		
-		103 //Scroll_Texture_Down
-		{
-			arg1
-			{
-				title = "Sidedef Part";
-				type = 12;
-				enum = "sidedef_part";
-			}
-		}
 		
 		222
 		{
 			title = "Scroll Texture Model";
 			id = "Scroll_Texture_Model";
 			requiresactivation = false;
+			
+			arg0
+			{
+				title = "Line id";
+				type = 15;
+			}
 			
 			arg1
 			{
@@ -2147,13 +2914,6 @@ udmf
 			title = "Scroll Texture by Offsets";
 			id = "Scroll_Texture_Offsets";
 			requiresactivation = false;
-			
-			arg0
-			{
-				title = "Sidedef Part";
-				type = 12;
-				enum = "sidedef_part";
-			}
 		}
 	}
 
@@ -2187,7 +2947,7 @@ udmf
 		}
 		233
 		{
-			title = "Light Change to Darkest Neightbour";
+			title = "Light Change to Darkest Neighbour";
 			id = "Light_MinNeighbor";
 			
 			arg0
@@ -2198,7 +2958,7 @@ udmf
 		}
 		234
 		{
-			title = "Light Change to Brightest Neightbour";
+			title = "Light Change to Brightest Neighbour";
 			id = "Light_MaxNeighbor";
 			
 			arg0
@@ -2239,7 +2999,7 @@ udmf
 		
 		57
 		{
-			title = "Sector Set Portal (only for compatibility)";
+			title = "Sector Set Portal (legacy encapsulation)";
 			id = "Sector_SetPortal";
 			requiresactivation = false;
 			
@@ -2285,6 +3045,7 @@ udmf
 				title = "Opacity";
 			}
 		}
+		140 = NULL;	// not yet
 		185
 		{
 			title = "Sector Rotate Flat";
@@ -2360,64 +3121,66 @@ udmf
 				title = "Vertical Fractional";
 			}
 		}
-		188
-		{
-			title = "Sector Ceiling Scale";
-			id = "Sector_SetCeilingScale";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Horizontal Integral";
-			}
-			arg2
-			{
-				title = "Horizontal Fractional";
-			}
-			arg3
-			{
-				title = "Vertical Integral";
-			}
-			arg4
-			{
-				title = "Vertical Fractional";
-			}
-		}
-		189
-		{
-			title = "Sector Floor Scale";
-			id = "Sector_SetFloorScale";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Horizontal Integral";
-			}
-			arg2
-			{
-				title = "Horizontal Fractional";
-			}
-			arg3
-			{
-				title = "Vertical Integral";
-			}
-			arg4
-			{
-				title = "Vertical Fractional";
-			}
-		}		
+// This is tentative		
+//		188
+//		{
+//			title = "Sector Ceiling Scale";
+//			id = "Sector_SetCeilingScale";
+//			
+//			arg0
+//			{
+//				title = "Sector Tag";
+//				type = 13;
+//			}
+//			arg1
+//			{
+//				title = "Horizontal Integral";
+//			}
+//			arg2
+//			{
+//				title = "Horizontal Fractional";
+//			}
+//			arg3
+//			{
+//				title = "Vertical Integral";
+//			}
+//			arg4
+//			{
+//				title = "Vertical Fractional";
+//			}
+//		}
+//		189
+//		{
+//			title = "Sector Floor Scale";
+//			id = "Sector_SetFloorScale";
+//			
+//			arg0
+//			{
+//				title = "Sector Tag";
+//				type = 13;
+//			}
+//			arg1
+//			{
+//				title = "Horizontal Integral";
+//			}
+//			arg2
+//			{
+//				title = "Horizontal Fractional";
+//			}
+//			arg3
+//			{
+//				title = "Vertical Integral";
+//			}
+//			arg4
+//			{
+//				title = "Vertical Fractional";
+//			}
+//		}		
 		218
 		{
 			title = "Sector Wind";
 			id = "Sector_SetWind";
+			requiresactivation = false;
 			
 			arg0
 			{
@@ -2435,9 +3198,13 @@ udmf
 			}
 			arg3
 			{
-				title = "Use Line Vector";
-				type = 11;
-				enum = "noyes";
+				title = "Flags";
+				type = 12;
+				enum
+				{
+					1 = "Use line vector";
+					2 = "Use Heretic model";
+				}
 			}
 		}
 		219
@@ -2451,26 +3218,13 @@ udmf
 				title = "Sector Tag";
 				type = 13;
 			}
-			arg1
-			{
-				title = "Friction Amount";
-				type = 11;
-				enum
-				{
-					0 = "Use Line Length";
-					1 = "Very Sludgy";
-					50 = "Sludgy";
-					100 = "Normal";
-					200 = "Icy";
-					255 = "Very Icy";
-				}
-			}
 		}
 		
 		220
 		{
 			title = "Sector Current";
 			id = "Sector_SetCurrent";
+			requiresactivation = false;
 			
 			arg0
 			{
@@ -2488,7 +3242,39 @@ udmf
 			}
 			arg3
 			{
-				title = "Use Line Vector";
+				title = "Flags";
+				type = 12;
+				enum
+				{
+					1 = "Use line vector";
+					2 = "Use Heretic model";
+				}
+			}
+		}
+		
+		227
+		{
+			title = "Setup pusher or puller thing";
+			id = "PointPush_SetForce";
+			requiresactivation = false;
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Thing Tag";
+				type = 14;
+			}
+			arg2
+			{
+				title = "Strength";
+				default = 64;
+			}
+			arg3
+			{
+				title = "Use line vector";
 				type = 11;
 				enum = "noyes";
 			}
@@ -2510,12 +3296,13 @@ udmf
 				type = 11;
 				enum 
 				{
-					0 = "Very Easy";
-					1 = "Easy";
-					2 = "Normal";
-					3 = "Hard";
-					4 = "Nightmare!";
+					0 = "I'm too young to die!";
+					1 = "Hey, not too rough!";
+					2 = "Hurt me plenty!";
+					3 = "Ultra-violence!";
+					4 = "Nightmare!!";
 				}
+				default = 3;
 			}
 		}
 	}
@@ -2593,47 +3380,15 @@ udmf
 		}
 	}
 
-	static
-	{
-		title = "Static";
-		
-		190
-		{
-			title = "Static Init";
-			id = "Static_Init";
-			
-			arg0
-			{
-				title = "Sector Tag";
-				type = 13;
-			}
-			arg1
-			{
-				title = "Property";
-				type = 11;
-				enum
-				{
-					0 = "Set the gravity to the length of the linedef";
-					1 = "Set the light or fog color in a sector";
-					2 = "Set damage to the length of the linedef";
-					3 = "Define a sector link";
-					255 = "Use the line's upper texture as the sky in any tagged sectors";
-				}
-			}
-			arg2
-			{
-				title = "Flip Sky / Ceiling";
-			}
-			arg3
-			{
-				title = "Movement Type";
-			}
-		}
-	}
-
 	portal
 	{
 		title = "Portal";
+		9
+		{
+			title = "Line Horizon";
+			id = "Line_Horizon";
+			requiresactivation = false;
+		}
 		300
 		{
 			title = "Portal Define";
@@ -2662,16 +3417,20 @@ udmf
 			{
 				title = "Anchor line id";
 				type = 15;
+				tooltip = "Only for anchored, two-way and linked portals, specifies the target line for the portal to point to. Non-linked portals can also rotate the view, based on the relative orientation of the linedefs.";
 			}
 			arg3
 			{
 				title = "Z parameter";
 				type = 0;
+				tooltip = "For anchored and two-way anchored portal: specifies the visual Z offset. For linked portal: specifies the Z position where the portal will appear, relative to its default position (front sector's floor or ceiling height).";
 			}
 			arg4
 			{
 				title = "Flipped anchor";
-				type = 3;
+				type = 11;
+				enum = "noyes";
+				tooltip = "For anchored and two-way anchored portals: treat the anchored line as flipped, when calculating the rotation angle.";
 			}
 		}
 		301
@@ -2690,6 +3449,52 @@ udmf
 	elevator
 	{
 		title = "Elevator";
+		95
+		{
+			title = "Floor and Ceiling Lower by Value";
+			id = "FloorAndCeiling_LowerByValue";
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "flat_speeds";
+				default = 8;
+			}
+			arg2
+			{
+				title = "Lower by";
+			}
+		}
+		
+		96
+		{
+			title = "Floor and Ceiling Raise by Value";
+			id = "FloorAndCeiling_RaiseByValue";
+			
+			arg0
+			{
+				title = "Sector Tag";
+				type = 13;
+			}
+			
+			arg1
+			{
+				title = "Movement Speed";
+				type = 11;
+				enum = "flat_speeds";
+				default = 8;
+			}
+			
+			arg2
+			{
+				title = "Raise by";
+			}
+		}
 		
 		245
 		{
@@ -2706,12 +3511,12 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 32;
 			}
 		}
 		246
 		{
-			title = "Elevator Move to Activated Floor";
+			title = "Elevator Move to Current Floor";
 			id = "Elevator_MoveToFloor";
 			
 			arg0
@@ -2724,7 +3529,7 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 32;
 			}
 		}
 		247
@@ -2742,64 +3547,112 @@ udmf
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
-				default = 16;
+				default = 32;
 			}
 		}
 	}
 	polyobj
 	{
-		1	// Polyobject Start Line
+		2
 		{
-			arg3
+//			id = "Polyobj_RotateLeft";
+			arg1
 			{
-				title = "Set Line ID";
-				type = 0;
-			}
-		}
-		5	// Polyobject Explicit Line
-		{
-			arg4
-			{
-				title = "Set Line ID";
-				type = 0;
-			}
-		}
-	}
-	plane
-	{
-		181 //Plane_Align
-		{
+				default = 8;
+			}			
 			arg2
 			{
-				title = "Set Line ID";
-				type = 0;
+				default = 64;
 			}
 		}
-	}
-	scroll
-	{
-		52 //Scroll_Wall
+		3
 		{
-			arg0
+//			id = "Polyobj_RotateRight";
+			arg1
 			{
-				title = "Set Line ID";
-				type = 0;
+				default = 8;
+			}
+			arg2
+			{
+				default = 64;
 			}
 		}
-		221 //Scroll_Texture_Both
+		4
 		{
-			arg0
+//			id = "Polyobj_Move";
+			arg1
 			{
-				title = "Line ID";
-				type = 0;
+				default = 8;
+			}
+			arg2
+			{
+				default = 64;
+			}
+			arg3
+			{
+				default = 128;
 			}
 		}
-		222 //Scroll_Texture_Model
+		7
 		{
+//			id = "Polyobj_DoorSwing";		
+			arg2
+			{
+				default = 64;
+			}
+			arg3
+			{
+				default = 150;
+			}
+		}
+		8
+		{
+//			id = "Polyobj_DoorSlide";
+			arg4
+			{
+				default = 150;
+			}
+		}
+		87
+		{
+			title = "Polyobject stop movement";
+			id = "Polyobj_Stop";
 			arg0
 			{
-				title = "Set Line ID";
-				type = 0;
+				title = "Polyobject Number";
+				type = 25;
+			}
+		}
+		90
+		{
+//			id = "Polyobj_OR_RotateLeft";		
+			arg1
+			{
+				default = 8;
+			}
+			arg2
+			{
+				default = 64;
+			}
+		}
+		91
+		{
+//			id = "Polyobj_OR_RotateRight";
+			arg1
+			{
+				default = 8;
+			}
+			arg2
+			{
+				default = 64;
+			}
+		}
+		92
+		{
+//			id = "Polyobj_OR_Move";
+			arg1
+			{
+				default = 8;
 			}
 		}
 	}
@@ -2814,20 +3667,12 @@ udmf
 			}
 		}
 	}
-	teleport
+	line
 	{
-		215 //Teleport_Line
-		{
-			arg0
-			{
-				title = "Line ID";
-				type = 0;
-			}
-			arg1
-			{
-				title = "Target Line ID";
-				type = 0;
-			}
-		}
+		121 = NULL;
+	}
+	use
+	{
+		129 = NULL;	// not yet
 	}
 }

--- a/Build/Configurations/Includes/Eternity_misc.cfg
+++ b/Build/Configurations/Includes/Eternity_misc.cfg
@@ -384,7 +384,9 @@ thingflags_udmf
 	dormant = "Dormant";
 	translucent = "Translucent (25%)";
 	invisible = "Invisible";
-	
+	class1 = "Class 1";
+	class2 = "Class 2";
+	class3 = "Class 3";
 }
 
 // How thing flags should be compared (for the stuck thing error check)


### PR DESCRIPTION
Sorry for popping up again, but I think it's important that class1, class2, class3 become parts of the EE thing definitions, even if we don't have user-settable class slots yet in the port, just in case we plan to have Hexen compatibility straight in the EE namespace later...