### PR TITLE
Added support for dynamic thing range finders based on an argument value

### DIFF
--- a/Source/Core/Config/ArgumentInfo.cs
+++ b/Source/Core/Config/ArgumentInfo.cs
@@ -63,6 +63,7 @@ namespace CodeImp.DoomBuilder.Config
 		private readonly PixelColor rendercolor; //mxd
 		private readonly PixelColor minrangecolor; //mxd
 		private readonly PixelColor maxrangecolor; //mxd
+		private readonly PixelColor autorangecolor; //mxd
 		private readonly int minrange; //mxd
 		private readonly int maxrange; //mxd
 
@@ -82,6 +83,7 @@ namespace CodeImp.DoomBuilder.Config
 		public PixelColor RenderColor { get { return rendercolor; } } //mxd
 		public PixelColor MinRangeColor { get { return minrangecolor; } } //mxd
 		public PixelColor MaxRangeColor { get { return maxrangecolor; } } //mxd
+		public PixelColor AutoRangeColor { get { return autorangecolor; } } //mxd
 		public int MinRange { get { return minrange; } } //mxd
 		public int MaxRange { get { return maxrange; } } //mxd
 
@@ -127,6 +129,19 @@ namespace CodeImp.DoomBuilder.Config
 					General.ErrorLogger.Add(ErrorType.Error, "\"" + argspath + ".arg" + istr + "\": action argument \"" + this.title + "\": unable to get rendercolor from value \"" + rendercolor + "\"!");
 
 				this.rendercolor.a = HELPER_SHAPE_ALPHA;
+
+				// Get autorange settings
+				if (this.type == (int)UniversalType.ThingRange)
+				{
+					// Get autorangecolor
+					string autorangecolor = cfg.ReadSetting(argspath + ".arg" + istr + ".autorangecolor", string.Empty);
+					this.autorangecolor = General.Colors.Indication;
+
+					if (!string.IsNullOrEmpty(autorangecolor) && !ZDTextParser.GetColorFromString(autorangecolor, ref this.autorangecolor))
+						General.ErrorLogger.Add(ErrorType.Error, "\"" + argspath + ".arg" + istr + "\": action argument \"" + this.title + "\": unable to get autorangecolor from value \"" + autorangecolor + "\"!");
+
+					this.autorangecolor.a = RANGE_SHAPE_ALPHA;
+				}
 
 				// Get minrange settings
 				string minrange = cfg.ReadSetting(argspath + ".arg" + istr + ".minrange", string.Empty);
@@ -237,7 +252,7 @@ namespace CodeImp.DoomBuilder.Config
 
 		//mxd. Constructor for an argument info defined in DECORATE
 		internal ArgumentInfo(string actorname, string argtitle, string tooltip, string renderstyle, string rendercolor,
-			string minrange, string minrangecolor, string maxrange, string maxrangecolor,
+			string minrange, string minrangecolor, string maxrange, string maxrangecolor, string autorangecolor,
 			int type, int defaultvalue, string enumstr, IDictionary<string, EnumList> enums)
 		{
 			this.used = true;
@@ -267,6 +282,18 @@ namespace CodeImp.DoomBuilder.Config
 					General.ErrorLogger.Add(ErrorType.Error, actorname + ": action argument \"" + argtitle + "\": unable to get rendercolor from value \"" + rendercolor + "\"!");
 
 				this.rendercolor.a = HELPER_SHAPE_ALPHA;
+
+				// Get autorange settings
+				if (type == (int)UniversalType.ThingRange)
+				{
+					// Get autorangecolor
+					this.autorangecolor = General.Colors.Indication;
+
+					if (!string.IsNullOrEmpty(autorangecolor) && !ZDTextParser.GetColorFromString(autorangecolor, ref this.autorangecolor))
+						General.ErrorLogger.Add(ErrorType.Error, actorname + ": action argument \"" + this.title + "\": unable to get autorangecolor from value \"" + autorangecolor + "\"!");
+
+					this.autorangecolor.a = RANGE_SHAPE_ALPHA;
+				}
 
 				// Get minrange settings
 				if(int.TryParse(minrange, NumberStyles.Integer, CultureInfo.InvariantCulture, out this.minrange) && this.minrange > 0f)

--- a/Source/Core/Config/ThingTypeInfo.cs
+++ b/Source/Core/Config/ThingTypeInfo.cs
@@ -477,10 +477,11 @@ namespace CodeImp.DoomBuilder.Config
 				int defaultvalue = actor.GetPropertyValueInt("$arg" + i + "default", 0);
 				string argenum = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "enum"));
 				string argrenderstyle = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "renderstyle"));
-				string argrendercolor, minrange, maxrange, minrangecolor, maxrangecolor;
+				string argrendercolor, autorangecolor, minrange, maxrange, minrangecolor, maxrangecolor;
 				if(!string.IsNullOrEmpty(argrenderstyle))
 				{
 					argrendercolor = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "rendercolor"));
+					autorangecolor = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "autorangecolor"));
 					minrange = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "minrange"));
 					minrangecolor = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "minrangecolor"));
 					maxrange = ZDTextParser.StripQuotes(actor.GetPropertyAllValues("$arg" + i + "maxrange"));
@@ -488,11 +489,11 @@ namespace CodeImp.DoomBuilder.Config
 				}
 				else
 				{
-					argrendercolor = string.Empty; minrange = string.Empty; maxrange = string.Empty; minrangecolor = string.Empty; maxrangecolor = string.Empty;
+					argrendercolor = string.Empty; autorangecolor = string.Empty; minrange = string.Empty; maxrange = string.Empty; minrangecolor = string.Empty; maxrangecolor = string.Empty;
 				}
 				
 				args[i] = new ArgumentInfo(title, argtitle, argtooltip, argrenderstyle, argrendercolor, 
-					minrange, minrangecolor, maxrange, maxrangecolor, 
+					minrange,  minrangecolor, maxrange, maxrangecolor, autorangecolor, 
 					argtype, defaultvalue, argenum, General.Map.Config.Enums);
 			}
 

--- a/Source/Core/Types/UniversalType.cs
+++ b/Source/Core/Types/UniversalType.cs
@@ -49,5 +49,6 @@ namespace CodeImp.DoomBuilder.Types
 		ThingHeight = 24, //mxd
 		PolyobjectNumber = 25, //mxd
 		EnumOptionAndBits = 26, //mxd
+		ThingRange = 27
 	}
 }

--- a/Source/Plugins/BuilderModes/ClassicModes/ThingsMode.cs
+++ b/Source/Plugins/BuilderModes/ClassicModes/ThingsMode.cs
@@ -1243,11 +1243,13 @@ namespace CodeImp.DoomBuilder.BuilderModes
 						case ArgumentInfo.ArgumentRenderStyle.CIRCLE:
 							if(a.MinRange > 0) lines.AddRange(LinksCollector.MakeCircleLines(t.Position, a.MinRangeColor, a.MinRange, numsides));
 							if(a.MaxRange > 0) lines.AddRange(LinksCollector.MakeCircleLines(t.Position, a.MaxRangeColor, a.MaxRange, numsides));
+							if(a.Type == (int)UniversalType.ThingRange) lines.AddRange(LinksCollector.MakeCircleLines(t.Position, a.AutoRangeColor, t.Args[i], numsides));
 							break;
 
 						case ArgumentInfo.ArgumentRenderStyle.RECTANGLE:
 							if(a.MinRange > 0) lines.AddRange(LinksCollector.MakeRectangleLines(t.Position, a.MinRangeColor, a.MinRange));
 							if(a.MaxRange > 0) lines.AddRange(LinksCollector.MakeRectangleLines(t.Position, a.MaxRangeColor, a.MaxRange));
+							if (a.Type == (int)UniversalType.ThingRange) lines.AddRange(LinksCollector.MakeRectangleLines(t.Position, a.AutoRangeColor, t.Args[i]));
 							break;
 
 						case ArgumentInfo.ArgumentRenderStyle.NONE:break;


### PR DESCRIPTION
Reintroducing the argument type for ranger finders, so that the option for displaying the range radius can be dynamic based on the argument value itself, rather than hard coded in the decorate declaration.